### PR TITLE
Remove delimiter in levenshtein_with_edits method. 

### DIFF
--- a/DiarizationLM/diarizationlm/levenshtein.py
+++ b/DiarizationLM/diarizationlm/levenshtein.py
@@ -21,11 +21,10 @@ class EditOp(Enum):
 def levenshtein_with_edits(
     ref: str,
     hyp: str,
-    delimiter: str = " ",
     print_debug_info: bool = False) -> tuple[int, list[tuple[int, int]]]:
   align = []
-  s1 = ref.split(delimiter)
-  s2 = hyp.split(delimiter)
+  s1 = ref.split()
+  s2 = hyp.split()
   n1 = len(s1)
   n2 = len(s2)
   costs = np.zeros((n1+1, n2+1), dtype=np.int32)


### PR DESCRIPTION
The aim of this PR is to solve issue number #35: 

We don't need to use a delimiter in levenshtein_with_edits if we want to be consistent with how ref_text is split in `get_aligned_hyp_speakers`. 